### PR TITLE
Update Go version to 1.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - '1.17.6'
+  - '1.20'
 
 branches:
   only:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Medzoner/traefik-plugin-cors-preflight
 
-go 1.17
+go 1.20
 
 require gotest.tools v2.2.0+incompatible
 


### PR DESCRIPTION
Unable to install the plugin. The error is
```
traefik-67cf6fcc5d-lq2m4 traefik time="2024-02-28T11:09:51Z" level=error msg="Plugins are disabled because an error has occurred." error="unable to set up plugins environment: unable to download plugin github.com/Medzoner/traefik-plugin-cors-preflight: error: 500: {\"error\":\"Failed to get plugin github.com/Medzoner/traefik-plugin-cors-preflight@v1.0.4\"}\n"
```

Most likely the issue is related to Go lang version https://community.traefik.io/t/unable-to-download-plugin-error-500/20322